### PR TITLE
Update TFCameraViewController.m

### DIFF
--- a/Pod/Classes/TFCameraViewController.m
+++ b/Pod/Classes/TFCameraViewController.m
@@ -430,12 +430,10 @@
         AVCaptureDeviceInput *newVideoInput = [[AVCaptureDeviceInput alloc] initWithDevice:newCamera error:nil];
         [self.captureSession addInput:newVideoInput];
         
-        if (self.isVideoCamera) {
-            //Add mic input to the session
-            AVCaptureDevice *audioDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeAudio];
-            AVCaptureInput *audioInput = [AVCaptureDeviceInput deviceInputWithDevice:audioDevice error:nil];
-            [self.captureSession addInput:audioInput];
-        }
+        //Add mic input to the session
+        AVCaptureDevice *audioDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeAudio];
+        AVCaptureInput *audioInput = [AVCaptureDeviceInput deviceInputWithDevice:audioDevice error:nil];
+        [self.captureSession addInput:audioInput];
         
         //Commit all the configuration changes at once
         [self.captureSession commitConfiguration];


### PR DESCRIPTION
While uploading the video selfie it searches for the video asset's audio duration. But since on swapping the camera, the camera isn't on video mode, during recording a video there is no audio input. 

This makes sure that there is a default audio input which is used only on video recording.
