### PR TITLE
Added ability to allocate TFCameraViewController with default interface from Swift

### DIFF
--- a/Pod/Classes/TFCameraViewController.h
+++ b/Pod/Classes/TFCameraViewController.h
@@ -10,7 +10,7 @@
 /*!
  Call the following to init the Camera VC for display
  
- TFCameraViewController *cameraVC = [[TFCameraViewController alloc] initWithNibName:@"CameraOverlay" bundle:nil];
+ TFCameraViewController *cameraVC = [TFCameraViewController withDefaultInterface];
  */
 
 
@@ -51,8 +51,15 @@
 
 /*!
  This is the default instantion method. Incudes regular and selfie flash, video recording, camera swapping, tap to focus, and doubletap to switch cameras.
+ 
+ This is now deprecated, use [TFCameraViewController withDefaultInterface].
  */
-- (instancetype) initWithInterface;
+- (instancetype) initWithInterface __attribute__((deprecated("Replaced by +withDefaultInterface")));
+
+/*!
+ This is the default instantion method. Incudes regular and selfie flash, video recording, camera swapping, tap to focus, and doubletap to switch cameras.
+ */
++ (instancetype) withDefaultInterface;
 
 /*!
  Use these methods to register or remove the camera view controller for a color change notificaiton (all the button colors will change on the camera screen when this notification fires).

--- a/Pod/Classes/TFCameraViewController.m
+++ b/Pod/Classes/TFCameraViewController.m
@@ -64,8 +64,12 @@
 #pragma mark - Initializers
 - (instancetype) initWithInterface
 {
-    TFCameraViewController *cameraViewController = [[TFCameraViewController alloc] initWithNibName:@"CameraOverlay" bundle:[self podBundle]];
-    return cameraViewController;
+    return [super initWithNibName:@"CameraOverlay" bundle:[TFCameraViewController podBundle]];
+}
+
++ (instancetype) withDefaultInterface
+{
+    return [[TFCameraViewController alloc] initWithNibName:@"CameraOverlay" bundle:[self podBundle]];
 }
 
 #pragma mark - View Lifecycle
@@ -155,13 +159,13 @@
     [self setupCaptureSession];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didRotateFromInterfaceOrientation:) name:UIDeviceOrientationDidChangeNotification object:nil];
     
-    NSString *onImagePath = [[self podBundle] pathForResource:@"camera-flash" ofType:@"png"];
+    NSString *onImagePath = [[TFCameraViewController podBundle] pathForResource:@"camera-flash" ofType:@"png"];
     self.flashOnImage = [UIImage imageWithContentsOfFile:onImagePath];
     
-    NSString *offImagePath = [[self podBundle] pathForResource:@"camera-flash-on" ofType:@"png"];
+    NSString *offImagePath = [[TFCameraViewController podBundle] pathForResource:@"camera-flash-on" ofType:@"png"];
     self.flashOffImage = [UIImage imageWithContentsOfFile:offImagePath];
     
-    NSString *swapImagePath = [[self podBundle] pathForResource:@"camera-swap" ofType:@"png"];
+    NSString *swapImagePath = [[TFCameraViewController podBundle] pathForResource:@"camera-swap" ofType:@"png"];
     self.swapCameraImage = [UIImage imageWithContentsOfFile:swapImagePath];
     
     [self setupFlashButton];
@@ -577,14 +581,14 @@
             [device lockForConfiguration:nil];
             
             if (device.flashMode == AVCaptureFlashModeOff) {
-                NSString *imagePath = [[self podBundle] pathForResource:@"camera-flash-on" ofType:@"png"];
+                NSString *imagePath = [[TFCameraViewController podBundle] pathForResource:@"camera-flash-on" ofType:@"png"];
                 UIImage *flashButtonImage = [UIImage imageWithContentsOfFile:imagePath];
                 flashButtonImage = [flashButtonImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
                 self.flashButton.tintColor = self.appColor;
                 [self.flashButton setImage:flashButtonImage forState:UIControlStateNormal];
                 [device setFlashMode:AVCaptureFlashModeOn];
             } else {
-                NSString *imagePath = [[self podBundle] pathForResource:@"camera-flash" ofType:@"png"];
+                NSString *imagePath = [[TFCameraViewController podBundle] pathForResource:@"camera-flash" ofType:@"png"];
                 UIImage *flashButtonImage = [UIImage imageWithContentsOfFile:imagePath];
                 flashButtonImage = [flashButtonImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
                 self.flashButton.tintColor = self.appColor;
@@ -728,9 +732,9 @@
     [self setupSwapCameraButton];
 }
 
-- (NSBundle *) podBundle
++ (NSBundle *) podBundle
 {
-    NSBundle *podBundle = [NSBundle bundleForClass:self.classForCoder];
+    NSBundle *podBundle = [NSBundle bundleForClass:self.class];
     NSURL *bundleURL = [podBundle URLForResource:@"TFCamera" withExtension:@"bundle"];
     
     return [NSBundle bundleWithURL:bundleURL];

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pod "TFCamera"
 
 Getting started with TFCamera is obscenely easy! Simply instantiate the camera ViewController and set its delegate with the following code and then present it wherever you'd like to use it (works great as a view in a UIPageViewController):
 ```
-TFCameraViewController *cameraVC = [[TFCameraViewController alloc] initWithInterface];
+TFCameraViewController *cameraVC = [TFCameraViewController withDefaultInterface];
 cameraVC.delegate = self;
 ```
 


### PR DESCRIPTION
Non default initializers are only callable from Swift if they have parameters. This changes adds a static method to allocate and initialize a TFCameraViewController with the default interface.

This change deprecates the initWithInterface method, as a static method is the preferred way to allocate and initialize a class with default values.

This change also removes the duplicate allocate call in initWithInterface.